### PR TITLE
Fix empty file crashing server issue

### DIFF
--- a/mms/serving_frontend.py
+++ b/mms/serving_frontend.py
@@ -426,6 +426,7 @@ class ServingFrontend(object):
                     file_data = input_file.read()
                     assert isinstance(file_data, (str, bytes)), 'Image file buffer should be type str or ' \
                                                                 'bytes, but got %s' % (type(file_data))
+                    assert len(file_data) > 0, "Got empty file for %s." % (name)
                     input_data.append(file_data)
             except Exception as e:
                 logger.error(str(e))


### PR DESCRIPTION
Although preprocess/inference/postprocess have been wrapped up by try/except block, passing empty image will cause opencv to crash server. A check for nonempty file needs to be added.

Thank @aaronmarkham for report this bug.

I discussed this with Jun. The root cause is that mxnet backend doesn't throw an exception. He will look into it and fix the root issue. I'll close this PR for now.