### PR TITLE
Adding integration test module with SSD end to end example using pytest

### DIFF
--- a/dms/tests/README.md
+++ b/dms/tests/README.md
@@ -1,8 +1,8 @@
 # Testing DMS
 
-## Unit Tests
+## Pre-requisites
 
-You will need some additional Python modules to run the unit tests.
+You will need some additional Python modules to run the unit tests and integration tests.
 
 ```bash
 sudo pip install mock pytest
@@ -15,11 +15,17 @@ git clone https://github.com/awslabs/deep-model-server.git
 cd deep-model-server
 ```
 
-Then you can run the unit tests with the following:
+## Unit Tests
+
+You can run the unit tests with the following:
 
 ```bash
-python -m pytest mms/tests/unit_tests/
+python -m pytest dms/tests/unit_tests/
 ```
 ## CI Tests
 
-TODO: add comments about where they're hosted, etc.
+You can run the integration tests with the following:
+ 
+```bash
+python -m pytest dms/test/integration_tests/
+```

--- a/dms/tests/integration_tests/README.md
+++ b/dms/tests/integration_tests/README.md
@@ -1,8 +1,0 @@
-# Deep Model Server Integration Tests
-
-## Pre-requisites
-
-```
-pip install nose
-```
-## Run CI tests

--- a/dms/tests/integration_tests/extend_export_predict_service_test.py
+++ b/dms/tests/integration_tests/extend_export_predict_service_test.py
@@ -1,26 +1,17 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# Licensed under the Apache License, Version 2.0 (the "License").
-# You may not use this file except in compliance with the License.
-# A copy of the License is located at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# or in the "license" file accompanying this file. This file is distributed
-# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied. See the License for the specific language governing
-# permissions and limitations under the License.
-
 import json
 import subprocess
 import time
 import os
+import sys
+import shutil
 
+from threading import Thread
 from urllib2 import urlopen, URLError, HTTPError
-from nose.tools import with_setup
-# This is used to store the process ID of the DMS server started.
-# This is then used in tear_down to shutdown the server.
-dms_process = None
+
+from dms import export_model, mxnet_model_server
 
 
-def _download_file(url):
+def _download_file(download_dir, url):
     """
         Helper function to download the file from specified url
     :param url: File to download
@@ -29,7 +20,7 @@ def _download_file(url):
     try:
         f = urlopen(url)
         print("Downloading - {}".format(url))
-        with open(os.path.basename(url), "wb") as local_file:
+        with open(os.path.join(download_dir, os.path.basename(url)), "wb") as local_file:
             local_file.write(f.read())
     except HTTPError, e:
         print("Failed to download {}. HTTP Error {}".format(url, e.code))
@@ -37,52 +28,56 @@ def _download_file(url):
         print("Failed to download {}. HTTP Error {}".format(url, e.reason))
 
 
-def setup_ssd_server():
+def setup_ssd_server(tmpdir):
     """
         Downloads and Setup the SSD model server.
     :return: None
     """
-
-    # Download the model files.
-    _download_file("https://s3.amazonaws.com/mms-models/examples/resnet50_ssd/resnet50_ssd_model-symbol.json")
-    _download_file("https://s3.amazonaws.com/mms-models/examples/resnet50_ssd/resnet50_ssd_model-0000.params")
+    # Download the files required for SSD model in temp folder.
+    _download_file(tmpdir, "https://s3.amazonaws.com/model-server/models/resnet50_ssd/resnet50_ssd_model-symbol.json")
+    _download_file(tmpdir, "https://s3.amazonaws.com/model-server/models/resnet50_ssd/resnet50_ssd_model-0000.params")
+    _download_file(tmpdir, "https://s3.amazonaws.com/model-server/models/resnet50_ssd/synset.txt")
+    _download_file(tmpdir, "https://s3.amazonaws.com/model-server/models/resnet50_ssd/signature.json")
+    _download_file(tmpdir, "https://s3.amazonaws.com/model-server/models/resnet50_ssd/ssd_service.py")
 
     # Download input image.
-    _download_file("https://s3.amazonaws.com/mms-models/examples/resnet50_ssd/street.jpg")
-
-    # List
-    output = subprocess.check_output('pwd; ls -l', shell=True)
-    print("Hellooo... ")
-    print(output)
+    _download_file(tmpdir, "https://s3.amazonaws.com/model-server/models/resnet50_ssd/street.jpg")
 
     # Export the model.
-    subprocess.popen('cp examples/ssd/synset.txt .')
-    subprocess.popen('cp examples/ssd/signature.json .')
-    subprocess.popen("deep-model-export --model-name resnet50_ssd_model --model-path .")
+    print("Exporting the deep model server model...")
+    sys.argv = ['deep-model-export']
+    sys.argv.append("--model-name")
+    sys.argv.append("{}/resnet50_ssd_model".format(tmpdir))
+    sys.argv.append("--model-path")
+    sys.argv.append(tmpdir)
+    export_model.export()
 
     # Start the deep model server for SSD
     print("Starting SSD Deep Model Server for test..")
-    global dms_process
-    dms_process = subprocess.popen("deep-model-server --models SSD=resnet50_ssd_model.model --service "
-                                   "examples/ssd/ssd_service.py &", shell=False)
-    time.sleep(5)
+
+    # Set argv parameters
+    sys.argv = ['deep-model-server']
+    sys.argv.append("--models")
+    sys.argv.append("SSD={}/resnet50_ssd_model.model".format(tmpdir))
+    sys.argv.append("--service")
+    sys.argv.append("{}/ssd_service.py".format(tmpdir))
+    mxnet_model_server.start_serving()
 
 
-def teardown_ssd_server():
-    """
-        Terminates the SSD server started for the test.
-    :return: None
-    """
-    print("Terminating SSD Deep Model Server..")
-    if dms_process is not None:
-        dms_process.terminate()
+def cleanup(tmpdir):
+    print("Deleting all downloaded resources for SSD Deep Model Server Integration Test")
+    shutil.rmtree(tmpdir)
 
 
-@with_setup(setup_ssd_server, teardown_ssd_server)
-def test_ssd_extend_export_predict_service():
-    output = subprocess.check_output('curl -X POST http://127.0.0.1:8080/SSD/predict -F "input0=@street.jpg"',
-                                     shell=True)
-    predictions = json.dumps(json.loads(output))['prediction']
+def test_ssd_extend_export_predict_service(tmpdir):
+    start_test_server_thread = Thread(target = setup_ssd_server, args=(str(tmpdir),))
+    start_test_server_thread.daemon = True
+    start_test_server_thread.start()
+    time.sleep(10)
+    output = subprocess.check_output('curl -X POST http://127.0.0.1:8080/SSD/predict -F "input0=@{}/street.jpg"'.format(str(tmpdir)), shell=True)
+    predictions = json.dumps(json.loads(output))
     # Assert objects are detected.
     assert predictions is not None
     assert len(predictions) > 0
+    # Cleanup
+    cleanup(str(tmpdir))

--- a/examples/ssd/README.md
+++ b/examples/ssd/README.md
@@ -14,15 +14,15 @@ The inference service would return the response in the format - '[(object_class,
 ## Step 1 - Download the pre-trained SSD Model
 
 ```bash
- wget https://s3.amazonaws.com/dms-models/resnet50_ssd/resnet50_ssd_model-symbol.json
- wget https://s3.amazonaws.com/dms-models/resnet50_ssd/resnet50_ssd_model-0000.params
+ wget https://s3.amazonaws.com/model-server/models/resnet50_ssd/resnet50_ssd_model-symbol.json
+ wget https://s3.amazonaws.com/model-server/models/resnet50_ssd/resnet50_ssd_model-0000.params
 ```
 
 or
 
 Use these links to download the Symbol and Params files:
-1. <a href="https://s3.amazonaws.com/dms-models/resnet50_ssd/resnet50_ssd_model-symbol.json" download>resnet50_ssd_model-symbol.json</a>
-2. <a href="https://s3.amazonaws.com/dms-models/resnet50_ssd/resnet50_ssd_model-0000.params" download>resnet50_ssd_model-0000.params</a>
+1. <a href="https://s3.amazonaws.com/model-server/models/resnet50_ssd/resnet50_ssd_model-symbol.json" download>resnet50_ssd_model-symbol.json</a>
+2. <a href="https://s3.amazonaws.com/model-server/models/resnet50_ssd/resnet50_ssd_model-0000.params" download>resnet50_ssd_model-0000.params</a>
 
 **Note** params file is around 125 MB.
 
@@ -85,7 +85,7 @@ To understand more about the MultiboxPrior, anchor boxes, sizes and ratios, plea
 
 ## Step 3 - Prepare synset.txt with list of class names
 
-`[synset.txt](synsex.txt)` is where we define list of all classes detected by the model. The pre-trained SSD model used in the example is trained to detect 20 classes - person, car, aeroplane, bicycle and more. See synset.txt file for list of all classes.
+[synset.txt](synsex.txt) is where we define list of all classes detected by the model. The pre-trained SSD model used in the example is trained to detect 20 classes - person, car, aeroplane, bicycle and more. See synset.txt file for list of all classes.
 
 The list of classes in synset.txt will be loaded by DMS as list of labels in inference logic.
 
@@ -93,7 +93,7 @@ The list of classes in synset.txt will be loaded by DMS as list of labels in inf
 
 DMS allows users to extend the base service functionality and add more custom initialization, pre-processing, inference and post-processing.
 
-In this example, we extend `MXNetVisionService`, provided by DMS for vision inference use-cases, and reuse its input image preprocess functionality to resize and transform the image shape. We only add custom pre-processing and post-processing steps. See `[ssd_service.py](ssd_service.py)` for more details on how to extend the base service and add custom pre-processing and post-processing.
+In this example, we extend `MXNetVisionService`, provided by DMS for vision inference use-cases, and reuse its input image preprocess functionality to resize and transform the image shape. We only add custom pre-processing and post-processing steps. See [ssd_service.py](ssd_service.py) for more details on how to extend the base service and add custom pre-processing and post-processing.
 
 ## Step 5 - Export the model with deep-model-export CLI utility
 
@@ -228,11 +228,11 @@ For better visualization on the input and how we can use the inference output, s
 
 Input Image
 
-![Street Input Image](https://s3.amazonaws.com/dms-models/resnet50_ssd/street.jpg)
+![Street Input Image](https://s3.amazonaws.com/model-server/models/resnet50_ssd/street.jpg)
 
 Output Image
 
-![Street Output Image](https://s3.amazonaws.com/dms-models/resnet50_ssd/street_output.jpg)
+![Street Output Image](https://s3.amazonaws.com/model-server/models/resnet50_ssd/street_output.jpg)
 
 
 # References

--- a/examples/ssd/ssd_service.py
+++ b/examples/ssd/ssd_service.py
@@ -1,3 +1,13 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 import numpy as np
 import mxnet as mx
 from dms.utils.mxnet import image


### PR DESCRIPTION
* Adding integration test module for DMS. Updated README for instructions to run integration tests.
* Added SSD end to end integration test - export, custom service, prediction.
* Updated S3 link in SSD examples from dms-models to model-server bucket.
