### PR TITLE
Fix for OutOfDirectMemoryError.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,6 +147,13 @@ instance of the loaded model. This way only the memory locations in the loaded m
 preload_model=true
 ```
 
+### Prefer direct buffer
+Configuration parameter prefer_direct_buffer controls if the model server will be using direct memory specified by -XX:MaxDirectMemorySize. This parameter is for model server only and  doesn't affect other packages' usage of direct memory buffer. Default: false
+
+```properties
+prefer_direct_buffer=true
+```
+
 ### Restrict backend worker to access environment variable
 
 Environment variable may contains sensitive information like AWS credentials. Backend worker will execute arbitrary model's custom code, which may expose security risk. MMS provides a `blacklist_env_vars` property which allows user to restrict which environment variable can be accessed by backend worker.

--- a/frontend/modelarchive/src/test/resources/models/logging/service.py
+++ b/frontend/modelarchive/src/test/resources/models/logging/service.py
@@ -45,8 +45,9 @@ class LoggingService(object):
         :param model_input: transformed model input data
         :return: inference results
         """
+        time.sleep(0.01)
         logging.info("LoggingService inference [PID]: %d", os.getpid())
-        return ["{} OK".format(os.getpid())] * len(model_input)
+        return ["{} OK\n".format(os.getpid())] * len(model_input)
 
     def handle(self, data, context):
         """

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/ModelServer.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/ModelServer.java
@@ -27,6 +27,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.ServerChannel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -63,6 +64,7 @@ public class ModelServer {
     private List<ChannelFuture> futures = new ArrayList<>(2);
     private AtomicBoolean stopped = new AtomicBoolean(false);
     private ConfigManager configManager;
+    public static final int MAX_RCVBUF_SIZE = 4096;
 
     /** Creates a new {@code ModelServer} instance. */
     public ModelServer(ConfigManager configManager) {
@@ -249,7 +251,10 @@ public class ModelServer {
                 .channel(channelClass)
                 .childOption(ChannelOption.SO_LINGER, 0)
                 .childOption(ChannelOption.SO_REUSEADDR, true)
-                .childOption(ChannelOption.SO_KEEPALIVE, true);
+                .childOption(ChannelOption.SO_KEEPALIVE, true)
+                .childOption(
+                        ChannelOption.RCVBUF_ALLOCATOR,
+                        new FixedRecvByteBufAllocator(MAX_RCVBUF_SIZE));
         b.group(serverGroup, workerGroup);
 
         SslContext sslCtx = null;

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
@@ -86,6 +86,7 @@ public final class ConfigManager {
     private static final String MMS_PRELOAD_MODEL = "preload_model";
     private static final String MODEL_SERVER_HOME = "model_server_home";
     private static final String MMS_MODEL_STORE = "model_store";
+    private static final String MMS_PREFER_DIRECT_BUFFER = "prefer_direct_buffer";
 
     // Configuration which are not documented or enabled through environment variables
     private static final String USE_NATIVE_IO = "use_native_io";
@@ -252,6 +253,10 @@ public final class ConfigManager {
 
     public String getPreloadModel() {
         return getProperty(MMS_PRELOAD_MODEL, "false");
+    }
+
+    public boolean getPreferDirectBuffer() {
+        return Boolean.parseBoolean(getProperty(MMS_PREFER_DIRECT_BUFFER, "false"));
     }
 
     public int getNettyThreads() {
@@ -498,7 +503,9 @@ public final class ConfigManager {
                 + "\nMaximum Request Size: "
                 + prop.getProperty(MMS_MAX_REQUEST_SIZE, "6553500")
                 + "\nPreload model: "
-                + prop.getProperty(MMS_PRELOAD_MODEL, "false");
+                + prop.getProperty(MMS_PRELOAD_MODEL, "false")
+                + "\nPrefer direct buffer: "
+                + prop.getProperty(MMS_PREFER_DIRECT_BUFFER, "false");
     }
 
     public boolean useNativeIo() {

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/util/codec/ModelRequestEncoder.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/util/codec/ModelRequestEncoder.java
@@ -27,6 +27,10 @@ import java.util.Map;
 @ChannelHandler.Sharable
 public class ModelRequestEncoder extends MessageToByteEncoder<BaseModelRequest> {
 
+    public ModelRequestEncoder(boolean preferDirect) {
+        super(preferDirect);
+    }
+
     @Override
     protected void encode(ChannelHandlerContext ctx, BaseModelRequest msg, ByteBuf out) {
         if (msg instanceof ModelLoadModelRequest) {

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
@@ -61,7 +61,8 @@ public class WorkerThread implements Runnable {
     };
 
     static final long WORKER_TIMEOUT = ConfigManager.getInstance().isDebug() ? Long.MAX_VALUE : 2L;
-    static final ModelRequestEncoder ENCODER = new ModelRequestEncoder();
+    static final ModelRequestEncoder ENCODER =
+            new ModelRequestEncoder(ConfigManager.getInstance().getPreferDirectBuffer());
 
     private EventLoopGroup backendEventGroup;
     private int port;
@@ -233,6 +234,7 @@ public class WorkerThread implements Runnable {
             // WorkerThread is running in thread pool, the thread will be assigned to next
             // Runnable once this worker is finished. If currentThread keep holding the reference
             // of the thread, currentThread.interrupt() might kill next worker.
+            backendChannel.disconnect();
             currentThread.set(null);
             Integer exitValue = lifeCycle.getExitValue();
 

--- a/mms/model_server.py
+++ b/mms/model_server.py
@@ -106,6 +106,7 @@ def start():
             props = load_properties(mms_conf_file)
             vm_args = props.get("vmargs")
             if vm_args:
+                print("Warning: MMS is using non-default JVM parameters: {}".format(vm_args))
                 arg_list = vm_args.split()
                 if args.log_config:
                     for word in arg_list[:]:


### PR DESCRIPTION
- Use fixed RCVBUF buffer allocator instead of the adaptive one;
- Close socket channel on thread exit;
- Set preferDirect to false in MessageToByteEncoder.

Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:

## Description of changes:

## Testing done:

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/multi-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
