### PR TITLE
Use sys.exit() instad of os._exit()

### DIFF
--- a/mms/model_service_worker.py
+++ b/mms/model_service_worker.py
@@ -181,7 +181,7 @@ class MXNetModelServiceWorker(object):
             finally:
                 cl_socket.shutdown(socket.SHUT_RDWR)
                 cl_socket.close()
-                os._exit(1)
+                sys.exit(0)
 
     def run_server(self):
         """


### PR DESCRIPTION
Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:

## Description of changes:

## Testing done:

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/multi-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
