### PR TITLE
Removing MXNet reference from logs

### DIFF
--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerLifeCycle.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerLifeCycle.java
@@ -246,7 +246,7 @@ public class WorkerLifeCycle {
                         continue;
                     }
 
-                    if ("MXNet worker started.".equals(result)) {
+                    if ("MMS worker started.".equals(result)) {
                         lifeCycle.setSuccess(true);
                     } else if (result.startsWith("[PID]")) {
                         lifeCycle.setPid(Integer.parseInt(result.substring("[PID] ".length())));

--- a/mms/model_service_worker.py
+++ b/mms/model_service_worker.py
@@ -197,7 +197,7 @@ class MXNetModelServiceWorker(object):
 
         self.sock.listen(128)
         logging.info("[PID] %d", os.getpid())
-        logging.info("MXNet worker started.")
+        logging.info("Backend worker started.")
         logging.info("Python runtime: %s", platform.python_version())
         while True:
             if self.service is None and self.preload is True:

--- a/mms/model_service_worker.py
+++ b/mms/model_service_worker.py
@@ -197,7 +197,7 @@ class MXNetModelServiceWorker(object):
 
         self.sock.listen(128)
         logging.info("[PID] %d", os.getpid())
-        logging.info("Backend worker started.")
+        logging.info("MMS worker started.")
         logging.info("Python runtime: %s", platform.python_version())
         while True:
             if self.service is None and self.preload is True:


### PR DESCRIPTION
As the project is Multi Model Server, reference to MXNet in the logs seem redundant. When MMS is used with PyTorch, the worker logs `MXNet worker started` which is confusing.

Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:

## Description of changes:

## Testing done:

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/multi-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
