### PR TITLE
Update MacOS Java installation guide in Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Before proceeding further with this document, make sure you have the following p
 
     For macOS:
     ```bash
-    brew tap caskroom/versions
+    brew tap homebrew/cask-versions
     brew update
     brew cask install java8
     ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Before proceeding further with this document, make sure you have the following p
     ```bash
     brew tap homebrew/cask-versions
     brew update
-    brew cask install java8
+    brew cask install adoptopenjdk8
     ```
 
 ### Installing Multi Model Server with pip


### PR DESCRIPTION
## Issue #, if available:

## Description of changes:

The existing command in the tutorial is deprecated. Please consider updating it to the latest one for avoiding confusion or misleading newcomers.

Currently using the given command will lead to the following errors:
`Error: caskroom/versions was moved. Tap homebrew/cask-versions instead.`

Please refer to [https://github.com/Homebrew/homebrew-cask-versions](https://github.com/Homebrew/homebrew-cask-versions) or [https://stackoverflow.com/questions/44632292/how-to-install-specific-java-version-using-homebrew](https://stackoverflow.com/questions/44632292/how-to-install-specific-java-version-using-homebrew).

## Testing done:

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/multi-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
