### PR TITLE
Update Docker file to MXNet 1.6

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -21,7 +21,7 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN update-alternatives --install /usr/local/bin/pip pip /usr/local/bin/pip3 1
 
 RUN pip install --no-cache-dir multi-model-server \
-    && pip install --no-cache-dir mxnet-mkl==1.4.0
+    && pip install --no-cache-dir mxnet-mkl==1.6.0
 
 RUN useradd -m model-server \
     && mkdir -p /home/model-server/tmp

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -21,7 +21,7 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN update-alternatives --install /usr/local/bin/pip pip /usr/local/bin/pip3 1
 
 RUN pip install --no-cache-dir multi-model-server \
-    && pip install --no-cache-dir mxnet-cu92mkl==1.4.0
+    && pip install --no-cache-dir mxnet-cu92mkl==1.6.0
 
 RUN useradd -m model-server \
     && mkdir -p /home/model-server/tmp


### PR DESCRIPTION
## Issue #, if available:
No issue is open...

## Description of changes:
Update MXNet version to 1.6 on 2 Dockerfiles CPU and GPU.
The PIP package already suggest the latest version of MXNet.
This only to keep the containers and non Docker installations the same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
