### PR TITLE
Clean up resources after worker thread is terminated

### DIFF
--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -10,7 +10,7 @@ phases:
       - pip install pip -U
       - pip install future
       - pip install Pillow
-      - pip install pytest
+      - pip install pytest==4.0.0
       - pip install wheel
       - pip install twine
       - pip install pytest-mock -U

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkLoadManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkLoadManager.java
@@ -156,10 +156,12 @@ public class WorkLoadManager {
                 logger.warn(
                         "WorkerThread interrupted during waitFor, possible asynch resource cleanup.");
                 future.complete(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+                return future;
             }
             if (!workerDestroyed) {
                 logger.warn("WorkerThread timed out while cleaning, please resend request.");
                 future.complete(HttpResponseStatus.REQUEST_TIMEOUT);
+                return future;
             }
         }
         future.complete(HttpResponseStatus.OK);

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerLifeCycle.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerLifeCycle.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Scanner;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -217,7 +218,7 @@ public class WorkerLifeCycle {
         private InputStream is;
         private boolean error;
         private WorkerLifeCycle lifeCycle;
-        private boolean isRunning = true;
+        private AtomicBoolean isRunning = new AtomicBoolean(true);
         static final org.apache.log4j.Logger loggerModelMetrics =
                 org.apache.log4j.Logger.getLogger(ConfigManager.MODEL_METRICS_LOGGER);
 
@@ -229,13 +230,13 @@ public class WorkerLifeCycle {
         }
 
         public void terminate() {
-            isRunning = false;
+            isRunning.set(false);
         }
 
         @Override
         public void run() {
             try (Scanner scanner = new Scanner(is, StandardCharsets.UTF_8.name())) {
-                while (isRunning && scanner.hasNext()) {
+                while (isRunning.get() && scanner.hasNext()) {
                     String result = scanner.nextLine();
                     if (result == null) {
                         break;

--- a/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
+++ b/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
@@ -1312,7 +1312,7 @@ public class ModelServerTest {
         Scanner logscanner = new Scanner(logfile, "UTF-8");
         while (logscanner.hasNextLine()) {
             String line = logscanner.nextLine();
-            if (line.contains("LoggingService exit")) {
+            if (line.contains("Model logging unregistered")) {
                 count = count + 1;
             }
         }


### PR DESCRIPTION
## Description of changes:
* Terminate err and out ReaderThreads after its corresponding WorkerThread has been terminated
* Clean up FDs associated with a terminated WorkerThread
* Pins [pytest](https://github.com/pytest-dev/pytest/issues/3518) version in CI test to avoid error `fixture is being applied more than once to the same function`

## Testing done (Ubuntu18.04):
* Stress tested for 450000 iterations of model load and unload
* CI [tests](https://github.com/awslabs/multi-model-server/blob/master/ci/README.md) successful

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
