### PR TITLE
Update Netty / Log4j versions

### DIFF
--- a/frontend/gradle.properties
+++ b/frontend/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx1024M
-netty_version=4.1.24.Final
-slf4j_api_version=1.7.25
-slf4j_log4j12_version=1.7.25
+netty_version=4.1.50.Final
+slf4j_api_version=1.7.30
+slf4j_log4j12_version=1.7.30
 gson_version=2.8.5
 commons_cli_version=1.3.1
 testng_version=6.8.1


### PR DESCRIPTION
Upgrades Netty / Lo4j version to address CVE.

```CVE-2019-20445 / CVE-2019-20444 / CVE-2019-17571 / CVE-2019-16869```
