### PR TITLE
remove lock

### DIFF
--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/Model.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/Model.java
@@ -22,7 +22,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +37,6 @@ public class Model {
     private int maxBatchDelay;
     private String preloadModel;
     private AtomicInteger port; // Port on which the model server is running
-    private ReentrantLock lock;
     private int responseTimeout;
     private WorkerThread serverThread;
     // Total number of subsequent inference request failures
@@ -57,7 +55,6 @@ public class Model {
         jobsDb.putIfAbsent(DEFAULT_DATA_QUEUE, new LinkedBlockingDeque<>(queueSize));
         failedInfReqs = new AtomicInteger(0);
         port = new AtomicInteger(-1);
-        lock = new ReentrantLock();
     }
 
     public String getModelName() {
@@ -152,7 +149,6 @@ public class Model {
         }
 
         try {
-            lock.lockInterruptibly();
             long maxDelay = maxBatchDelay;
             jobsQueue = jobsDb.get(DEFAULT_DATA_QUEUE);
 
@@ -176,9 +172,7 @@ public class Model {
             }
             logger.trace("sending jobs, size: {}", jobsRepo.size());
         } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
+            logger.debug("remove lock");
         }
     }
 


### PR DESCRIPTION
## Issue #, if available:

## Description of changes:
This changes is to remove the lock in function pollBatch(). The reason is that each WorkerThread calls pollBatch to get a batch requests from a LinkedBlockingDeque and load them into its own buffer. This lock is not necessary since LinkedBlockingDeque is thread safe.

## Testing done:
The test was done at local environment. The test configuration:
inference_address=http://127.0.0.1:8080
management_address=http://127.0.0.1:8081
model_store=../modelarchive/src/test/resources/models
load_models=squeezenet_v1.1.mar
preload_model=true
default_workers_per_model=2
async_logging=true
default_response_timeout=120
unregister_model_timeout=120
max_request_size=10485760
enable_envvars_config=true
job_queue_size=100

Test case1: 
`
#!/bin/bash
begin=$(date +%s)
for i in {1..10000}
do
   #echo "Welcome $i times"
   curl -X POST  localhost:8080/predictions/squeezenet_v1.1 -T kitten.jpg
done
end=$(date +%s)
latency=`expr $end - $end`
echo $begin
echo $end
echo $latency
`
Test case2: call the following scripts 10 concurrently.
`
#!/bin/bash
begin=$(date +%s)
for i in {1..1000}
do
   #echo "Welcome $i times"
   curl -X POST  localhost:8080/predictions/squeezenet_v1.1 -T kitten.jpg
done
end=$(date +%s)
latency=`expr $end - $end`
echo $begin
echo $end
echo $latency
`
**To run CI tests on your changes refer [README.md](https://github.com/awslabs/multi-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
