### PR TITLE
Correct pip install command to the correct package

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -35,7 +35,7 @@ pip install mxnet-mkl
 or for GPU instance:
 
 ```bash
-pip install mxnet-cu90-mkl
+pip install mxnet-cu90mkl
 ```
 
 


### PR DESCRIPTION
The package mxnet-cu90-mkl is owned by a third-party. Correcting the package to mxnet-cu90mkl, which is hosted at https://pypi.org/project/mxnet-cu90mkl/, and recommended on the official page: https://mxnet.apache.org/versions/1.8.0/get_started?platform=linux&language=python&processor=gpu&environ=pip&

Before or while filing an issue please feel free to join our [slack community](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:
N/A

## Description of changes:
Change the pip install command to the correct one for the cu90 mkl variant of the mxnet package.

## Testing done:
Verified that the package exists and can be installed, and does not break the steps.

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/multi-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
