### PR TITLE
MMS - Support for custom error codes in custom handlers

### DIFF
--- a/docs/custom_service.md
+++ b/docs/custom_service.md
@@ -123,6 +123,18 @@ Here the ``` handle()``` method is our entry point that will be invoked by MMS, 
  
  This entry point is engaged in two cases: (1) when MMS is asked to scale a model up, to increase the number of backend workers (it is done either via a ```PUT /models/{model_name}``` request or a ```POST /models``` request with `initial-workers` option or during MMS startup when you use `--models` option (```multi-model-server --start --models {model_name=model.mar}```), ie., you provide model(s) to load) or (2) when MMS gets a ```POST /predictions/{model_name}``` request. (1) is used to scale-up or scale-down workers for a model. (2) is used as a standard way to run inference against a model. (1) is also known as model load time, and that is where you would normally want to put code for model initialization. You can find out more about these and other MMS APIs in [MMS Management API](./management_api.md) and [MMS Inference API](./inference_api.md)
 
+
+### Returning custom error codes 
+
+To return a custom error code back to the user use the `PredictionException` in the `mms.service` module.
+
+```python
+from mms.service import PredictionException
+def handler(data, context):
+    # Some unexpected error - returning error code 513
+    raise PredictionException("Some Prediction Error", 513)
+```
+
 ## Creating model archive with entry point 
 
 MMS, identifies the entry point to the custom service, from the manifest file. Thus file creating the model archive, one needs to mention the entry point using the ```--handler``` option. 

--- a/frontend/modelarchive/src/test/resources/models/custom-return-code/MAR-INF/MANIFEST.json
+++ b/frontend/modelarchive/src/test/resources/models/custom-return-code/MAR-INF/MANIFEST.json
@@ -1,0 +1,18 @@
+{
+  "specificationVersion": "1.0",
+  "implementationVersion": "1.0",
+  "description": "noop v1.0",
+  "modelServerVersion": "1.0",
+  "license": "Apache 2.0",
+  "runtime": "python",
+  "model": {
+    "modelName": "pred-custom-return-code",
+    "description": "Tests for custom return code",
+    "modelVersion": "1.0",
+    "handler": "service:handle"
+  },
+  "publisher": {
+    "author": "MXNet SDK team",
+    "email": "noreply@amazon.com"
+  }
+}

--- a/frontend/modelarchive/src/test/resources/models/custom-return-code/service.py
+++ b/frontend/modelarchive/src/test/resources/models/custom-return-code/service.py
@@ -1,0 +1,18 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from mms.service import PredictionException
+
+def handle(data, ctx):
+    # Data is not none in prediction request
+    # Python raises PredictionException with custom error code
+    if data is not None:
+        raise PredictionException("Some Prediction Error", 599)
+    return ["OK"]

--- a/mms/service.py
+++ b/mms/service.py
@@ -136,7 +136,7 @@ class PredictionException(Exception):
         self.message = message
         self.error_code = error_code
     def __str__(self):
-        return f"self.message : self.error_code"
+        return f"{self.message} : {self.error_code}"
 
 
 def emit_metrics(metrics):

--- a/mms/service.py
+++ b/mms/service.py
@@ -106,6 +106,9 @@ class Service(object):
         # noinspection PyBroadException
         try:
             ret = self._entry_point(input_batch, self.context)
+        except PredictionException as e:
+            logger.error("Prediction error", exc_info=True)
+            return create_predict_response(None, req_id_map, e.message, e.error_code)
         except MemoryError:
             logger.error("System out of memory", exc_info=True)
             return create_predict_response(None, req_id_map, "Out of resources", 507)
@@ -126,6 +129,14 @@ class Service(object):
         metrics.add_time(PREDICTION_METRIC, duration)
 
         return create_predict_response(ret, req_id_map, "Prediction success", 200, context=self.context)
+
+
+class PredictionException(Exception):
+    def __init__(self, message, error_code=500):
+        self.message = message
+        self.error_code = error_code
+    def __str__(self):
+        return f"self.message : self.error_code"
 
 
 def emit_metrics(metrics):

--- a/mms/service.py
+++ b/mms/service.py
@@ -135,7 +135,7 @@ class PredictionException(Exception):
     def __init__(self, message, error_code=500):
         self.message = message
         self.error_code = error_code
-        super().__init__(message)
+        super(PredictionException, self).__init__(message)
 
     def __str__(self):
         return "message : error_code".format(message=self.message, error_code=self.error_code)

--- a/mms/service.py
+++ b/mms/service.py
@@ -135,6 +135,8 @@ class PredictionException(Exception):
     def __init__(self, message, error_code=500):
         self.message = message
         self.error_code = error_code
+        super().__init__(message)
+
     def __str__(self):
         return f"{self.message} : {self.error_code}"
 

--- a/mms/service.py
+++ b/mms/service.py
@@ -138,7 +138,7 @@ class PredictionException(Exception):
         super().__init__(message)
 
     def __str__(self):
-        return f"{self.message} : {self.error_code}"
+        return "message : error_code".format(message=self.message, error_code=self.error_code)
 
 
 def emit_metrics(metrics):


### PR DESCRIPTION
Fixes - Allow custom HTTP status in mms.service.Service #961

## Description of changes:

Defines a custom exception `mms.service.PredictionException` enabling return of custom error codes

## Testing done:

Added unit tests / archive to test & verify the behavior in the PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
