### PR TITLE
issue_961

### DIFF
--- a/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
+++ b/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
@@ -1219,9 +1219,9 @@ public class ModelServerTest {
         channel.writeAndFlush(req);
         latch.await();
 
-        StatusResponse status = JsonUtils.GSON.fromJson(result, StatusResponse.class);
-        Assert.assertEquals(status.getMessage(), "Some Prediction Error");
-        Assert.assertEquals(status.getCode(), 599);
+        ErrorResponse resp = JsonUtils.GSON.fromJson(result, ErrorResponse.class);
+        Assert.assertEquals(resp.getMessage(), "Some Prediction Error");
+        Assert.assertEquals(resp.getCode(), 599);
         channel.close();
 
         // Unload the model

--- a/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
+++ b/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
@@ -1219,7 +1219,9 @@ public class ModelServerTest {
         channel.writeAndFlush(req);
         latch.await();
 
-        Assert.assertEquals(httpStatus.code(), 599);
+        StatusResponse status = JsonUtils.GSON.fromJson(result, StatusResponse.class);
+        Assert.assertEquals(status.getMessage(), "Some Prediction Error");
+        Assert.assertEquals(status.getCode(), 599);
         channel.close();
 
         // Unload the model

--- a/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
+++ b/frontend/server/src/test/java/com/amazonaws/ml/mms/ModelServerTest.java
@@ -1222,19 +1222,6 @@ public class ModelServerTest {
         ErrorResponse resp = JsonUtils.GSON.fromJson(result, ErrorResponse.class);
         Assert.assertEquals(resp.getMessage(), "Some Prediction Error");
         Assert.assertEquals(resp.getCode(), 599);
-        channel.close();
-
-        // Unload the model
-        channel = connect(true);
-        httpStatus = null;
-        latch = new CountDownLatch(1);
-        Assert.assertNotNull(channel);
-        req =
-                new DefaultFullHttpRequest(
-                        HttpVersion.HTTP_1_1, HttpMethod.DELETE, "/models/custom-return-code");
-        channel.writeAndFlush(req);
-        latch.await();
-        Assert.assertEquals(httpStatus, HttpResponseStatus.OK);
     }
 
     private void testErrorBatch() throws InterruptedException {

--- a/mms/service.py
+++ b/mms/service.py
@@ -138,7 +138,7 @@ class PredictionException(Exception):
         super(PredictionException, self).__init__(message)
 
     def __str__(self):
-        return "message : error_code".format(message=self.message, error_code=self.error_code)
+        return "{message} : {error_code}".format(message=self.message, error_code=self.error_code)
 
 
 def emit_metrics(metrics):


### PR DESCRIPTION
Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:
#961 
## Description of changes:
fix prediction customer code exception string format
## Testing done:
unit test 
manual test
curl -X POST http://127.0.0.1:8080/predictions/customer
{
  "code": 599,
  "type": "InternalServerException",
  "message": "Some Prediction Error"
}


**To run CI tests on your changes refer [README.md](https://github.com/awslabs/multi-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
