### PR TITLE
set preload_model default as null for register model request

### DIFF
--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/http/messages/RegisterModelRequest.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/http/messages/RegisterModelRequest.java
@@ -72,7 +72,7 @@ public class RegisterModelRequest {
         synchronous = true;
         initialWorkers = ConfigManager.getInstance().getConfiguredDefaultWorkersPerModel();
         responseTimeout = -1;
-        preloadModel = "false";
+        preloadModel = null;
     }
 
     public String getModelName() {


### PR DESCRIPTION
Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:
#977 
## Description of changes:

## Testing done:

config.properties:
vmargs=-Xmx128m -XX:-UseLargePages -XX:+UseG1GC -XX:MaxMetaspaceSize=32M -XX:MaxDirectMemorySize=10m -XX:+ExitOnOutOfMemoryError
model_store=/opt/ml/model
load_models=ALL
inference_address=http://0.0.0.0:8080
management_address=http://0.0.0.0:8081
preload_model=true

register model request:
curl -v -X POST "http://localhost:8081/models?initial_workers=1&synchronous=false&url=https%3A%2F%2Fs3.amazonaws.com%2Fmodel-server%2Fmodel_archive_1.0%2Fsqueezenet_v1.1.mar"

server log:
2021-11-29 21:45:41,072 [INFO ] W-9000-squeezenet_v1.1-stdout com.amazonaws.ml.mms.wlm.WorkerLifeCycle - model_service_worker started with args: --sock-type unix --sock-name /home/model-server/tmp/.mms.sock.9000 --handler mxnet_vision_service:handle --model-path /home/model-server/tmp/models/674bbff228fdc041fadbef6f515e86dd --model-name squeezenet_v1.1 --preload-model true --tmp-dir /home/model-server/tmp

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/multi-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
