### PR TITLE
Add support for detecting the number of available Neuron cores

### DIFF
--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
@@ -12,6 +12,7 @@
  */
 package com.amazonaws.ml.mms.util;
 
+import com.amazonaws.ml.mms.util.JsonUtils;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -19,6 +20,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -67,6 +70,7 @@ public final class ConfigManager {
     private static final String MMS_NETTY_CLIENT_THREADS = "netty_client_threads";
     private static final String MMS_JOB_QUEUE_SIZE = "job_queue_size";
     private static final String MMS_NUMBER_OF_GPU = "number_of_gpu";
+    private static final String MMS_NUMBER_OF_NEURON_CORES = "number_of_neuron_cores";
     private static final String MMS_ASYNC_LOGGING = "async_logging";
     private static final String MMS_CORS_ALLOWED_ORIGIN = "cors_allowed_origin";
     private static final String MMS_CORS_ALLOWED_METHODS = "cors_allowed_methods";
@@ -142,6 +146,13 @@ public final class ConfigManager {
                         Integer.min(
                                 getAvailableGpu(),
                                 getIntProperty(MMS_NUMBER_OF_GPU, Integer.MAX_VALUE))));
+
+        prop.setProperty(
+                MMS_NUMBER_OF_NEURON_CORES,
+                String.valueOf(
+                        Integer.min(
+                                getAvailableNeuronCores(),
+                                getIntProperty(MMS_NUMBER_OF_NEURON_CORES, Integer.MAX_VALUE))));
 
         String pythonExecutable = args.getPythonExecutable();
         if (pythonExecutable != null) {
@@ -258,6 +269,10 @@ public final class ConfigManager {
         return getIntProperty(MMS_NUMBER_OF_GPU, 0);
     }
 
+    public int getNumberOfNeuronCores() {
+        return getIntProperty(MMS_NUMBER_OF_NEURON_CORES, 0);
+    }
+
     public String getMmsDefaultServiceHandler() {
         return getProperty(MMS_DEFAULT_SERVICE_HANDLER, null);
     }
@@ -282,6 +297,9 @@ public final class ConfigManager {
 
         if (workers == 0) {
             workers = getNumberOfGpu();
+        }
+        if (workers == 0) {
+            workers = getNumberOfNeuronCores();
         }
         if (workers == 0) {
             workers = Runtime.getRuntime().availableProcessors();
@@ -453,6 +471,8 @@ public final class ConfigManager {
                 + System.getProperty("java.io.tmpdir")
                 + "\nNumber of GPUs: "
                 + getNumberOfGpu()
+                + "\nNumber of Neuron Cores: "
+                + getNumberOfNeuronCores()
                 + "\nNumber of CPUs: "
                 + runtime.availableProcessors()
                 + "\nMax heap size: "
@@ -582,6 +602,26 @@ public final class ConfigManager {
                 throw new AssertionError("Unexpected nvidia-smi response.");
             }
             return list.size() - 1;
+        } catch (IOException | InterruptedException e) {
+            return 0;
+        }
+    }
+
+    private static final class NeuronConfig{
+        int nc_count;
+    }
+
+    private static int getAvailableNeuronCores() {
+        try {
+            Process process =
+                    Runtime.getRuntime().exec("neuron-ls --json-output");
+            int ret = process.waitFor();
+            if (ret != 0) {
+                return 0;
+            }
+            Reader reader = new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8);
+            NeuronConfig[] results  = JsonUtils.GSON.fromJson(reader, NeuronConfig[].class);
+            return Arrays.stream(results).mapToInt(r -> r.nc_count).sum();
         } catch (IOException | InterruptedException e) {
             return 0;
         }

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
@@ -12,7 +12,7 @@
  */
 package com.amazonaws.ml.mms.util;
 
-import com.amazonaws.ml.mms.util.JsonUtils;
+import com.google.gson.annotations.SerializedName;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -607,10 +607,6 @@ public final class ConfigManager {
         }
     }
 
-    private static final class NeuronConfig{
-        int nc_count;
-    }
-
     private static int getAvailableNeuronCores() {
         try {
             Process process =
@@ -621,10 +617,15 @@ public final class ConfigManager {
             }
             Reader reader = new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8);
             NeuronConfig[] results  = JsonUtils.GSON.fromJson(reader, NeuronConfig[].class);
-            return Arrays.stream(results).mapToInt(r -> r.nc_count).sum();
+            return Arrays.stream(results).mapToInt(c -> c.numNeuronCores).sum();
         } catch (IOException | InterruptedException e) {
             return 0;
         }
+    }
+
+    private static final class NeuronConfig{
+	@SerializedName("nc_count")
+	private int numNeuronCores;
     }
 
     public static final class Arguments {


### PR DESCRIPTION
Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:

## Description of changes:
Similar to GPUs, when running on AWS Inf1 instance types, automatically detect the number of available Neuron cores and set the number of workers accordingly. 

## Testing done:
Ran tests on inf1, logs correctly show 16 neuron cores on an inf1.6xlarge. 
```
...
   Temp directory: /tmp
    Number of GPUs: 0
    Number of Neuron Cores: 16
    Number of CPUs: 24
    Max heap size: 10457 M
    Python executable: python
...
```

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/multi-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
