### PR TITLE
Explicitly terminate process in sigterm_handler

### DIFF
--- a/mms/model_service_worker.py
+++ b/mms/model_service_worker.py
@@ -161,6 +161,7 @@ class MXNetModelServiceWorker(object):
                 os.remove(node)
             except OSError:
                 pass
+        sys.exit(0)
 
     def start_worker(self, cl_socket):
         """


### PR DESCRIPTION
Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:

## Description of changes:
Just removing socket in sigterm_handler does not seem to kill the process. If a socket gets closed, the STREAM session detects the closing of connection and that should automatically kill process, however, this does not seem to work as expected and we can try explicitly terminating the process in the handler, after removing the socket.


## Testing done:

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/multi-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
