### PR TITLE
Fix misnamed model_url query parameter in openapi docs

### DIFF
--- a/frontend/server/src/test/resources/management_open_api.json
+++ b/frontend/server/src/test/resources/management_open_api.json
@@ -181,7 +181,7 @@
         "parameters": [
           {
             "in": "query",
-            "name": "model_url",
+            "name": "url",
             "description": "Model archive download url, support local file or HTTP(s) protocol. For S3, consider use pre-signed url.",
             "required": true,
             "schema": {


### PR DESCRIPTION
## Issue #, if available: no issue

## Description of changes:

The openapi documentation claims that there is a `model_url` query parameter for the `/models/` POST endpoint. However, it appears the parameter name is actually just `url`.

Observe:

```
❯ curl -X POST http://127.0.0.1:8080/models/\?model_name\=test_2.0\&model_url\=/opt/ml/model/test_2.0
{
  "code": 400,
  "type": "BadRequestException",
  "message": "Parameter url is required."
}
```

If `model_url` is changed to `url`, this works, however:

```
❯ curl -X POST http://127.0.0.1:8080/models/\?model_name\=test_2.0\&url\=/opt/ml/model/test_2.0
{
  "status": "Workers scaled"
}
```

Furthermore, this seems to be how it's even used in tests, e.g., [here](https://github.com/awslabs/multi-model-server/blob/c58e29b29faf8e45abcb73088b011f86b40845ef/tests/performance/tests/register_unregister/register_unregister.jmx#L68).

## Testing done:

I can set up a local environment to test this, but it's just a change to documentation, basically.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
