### PR TITLE
Add config for request timeout in seconds

### DIFF
--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/ModelServer.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/ModelServer.java
@@ -216,7 +216,7 @@ public class ModelServer {
                                 null,
                                 1,
                                 100,
-                                configManager.getDefaultResponseTimeout(),
+                                configManager.getDefaultResponseTimeoutSeconds(),
                                 defaultModelName,
                                 configManager.getPreloadModel());
                 modelManager.updateModel(archive.getModelName(), workers, workers);

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/http/ManagementRequestHandler.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/http/ManagementRequestHandler.java
@@ -188,13 +188,13 @@ public class ManagementRequestHandler extends HttpRequestHandlerChain {
         int maxBatchDelay = registerModelRequest.getMaxBatchDelay();
         int initialWorkers = registerModelRequest.getInitialWorkers();
         boolean synchronous = registerModelRequest.isSynchronous();
-        int responseTimeout = registerModelRequest.getResponseTimeout();
+        int responseTimeoutSeconds = registerModelRequest.getResponseTimeoutSeconds();
         String preloadModel = registerModelRequest.getPreloadModel();
         if (preloadModel == null) {
             preloadModel = ConfigManager.getInstance().getPreloadModel();
         }
-        if (responseTimeout == -1) {
-            responseTimeout = ConfigManager.getInstance().getDefaultResponseTimeout();
+        if (responseTimeoutSeconds == -1) {
+            responseTimeoutSeconds = ConfigManager.getInstance().getDefaultResponseTimeoutSeconds();
         }
         Manifest.RuntimeType runtimeType = null;
         if (runtime != null) {
@@ -217,7 +217,7 @@ public class ManagementRequestHandler extends HttpRequestHandlerChain {
                             handler,
                             batchSize,
                             maxBatchDelay,
-                            responseTimeout,
+                            responseTimeoutSeconds,
                             null,
                             preloadModel);
         } catch (IOException | InterruptedException | ExecutionException | TimeoutException e) {

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/http/messages/RegisterModelRequest.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/http/messages/RegisterModelRequest.java
@@ -41,7 +41,7 @@ public class RegisterModelRequest {
     private boolean synchronous;
 
     @SerializedName("response_timeout")
-    private int responseTimeout;
+    private int responseTimeoutSeconds;
 
     @SerializedName("url")
     private String modelUrl;
@@ -61,7 +61,15 @@ public class RegisterModelRequest {
                         "initial_workers",
                         ConfigManager.getInstance().getConfiguredDefaultWorkersPerModel());
         synchronous = Boolean.parseBoolean(NettyUtils.getParameter(decoder, "synchronous", "true"));
-        responseTimeout = NettyUtils.getIntParameter(decoder, "response_timeout", -1);
+
+        // TODO Fix this so it matches the documentation, where timeouts are specified in seconds.
+        // For now, we're being extra careful about backwards compatibility.
+        // So, assume parameter is in minutes, and convert to seconds internally.
+        responseTimeoutSeconds = 60 * NettyUtils.getIntParameter(decoder, "response_timeout", -1);
+        if (responseTimeoutSeconds < 0) {
+            responseTimeoutSeconds = -1;
+        }
+
         modelUrl = NettyUtils.getParameter(decoder, "url", null);
         preloadModel = NettyUtils.getParameter(decoder, "preload_model", null);
     }
@@ -71,7 +79,7 @@ public class RegisterModelRequest {
         maxBatchDelay = 100;
         synchronous = true;
         initialWorkers = ConfigManager.getInstance().getConfiguredDefaultWorkersPerModel();
-        responseTimeout = -1;
+        responseTimeoutSeconds = -1;
         preloadModel = null;
     }
 
@@ -103,8 +111,8 @@ public class RegisterModelRequest {
         return synchronous;
     }
 
-    public Integer getResponseTimeout() {
-        return responseTimeout;
+    public Integer getResponseTimeoutSeconds() {
+        return responseTimeoutSeconds;
     }
 
     public String getModelUrl() {

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/util/ConfigManager.java
@@ -61,7 +61,11 @@ public final class ConfigManager {
     private static final String MMS_LOAD_MODELS = "load_models";
     private static final String MMS_BLACKLIST_ENV_VARS = "blacklist_env_vars";
     private static final String MMS_DEFAULT_WORKERS_PER_MODEL = "default_workers_per_model";
+
     private static final String MMS_DEFAULT_RESPONSE_TIMEOUT = "default_response_timeout";
+    private static final String MMS_DEFAULT_RESPONSE_TIMEOUT_SECONDS =
+            "default_response_timeout_seconds";
+
     private static final String MMS_UNREGISTER_MODEL_TIMEOUT = "unregister_model_timeout";
     private static final String MMS_NUMBER_OF_NETTY_THREADS = "number_of_netty_threads";
     private static final String MMS_NETTY_CLIENT_THREADS = "netty_client_threads";
@@ -519,8 +523,20 @@ public final class ConfigManager {
         return Integer.parseInt(value);
     }
 
-    public int getDefaultResponseTimeout() {
-        return Integer.parseInt(prop.getProperty(MMS_DEFAULT_RESPONSE_TIMEOUT, "120"));
+    public int getDefaultResponseTimeoutSeconds() {
+        // TODO The MMS_DEFAULT_RESPONSE_TIMEOUT variable was never intended to represent minutes,
+        // but due to a bug that's what it did. We'd like to remove this and match the documented
+        // behavior, but for now we're being cautious about backward compatibility.
+
+        // Check both properties, prefer seconds if provided, convert to seconds for return value
+        int timeoutSeconds =
+                Integer.parseInt(prop.getProperty(MMS_DEFAULT_RESPONSE_TIMEOUT_SECONDS, "-1"));
+        if (timeoutSeconds < 0) {
+            int timeoutMinutes =
+                    Integer.parseInt(prop.getProperty(MMS_DEFAULT_RESPONSE_TIMEOUT, "120"));
+            timeoutSeconds = 60 * timeoutMinutes;
+        }
+        return timeoutSeconds;
     }
 
     public int getUnregisterModelTimeout() {

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/Model.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/Model.java
@@ -39,7 +39,7 @@ public class Model {
     private String preloadModel;
     private AtomicInteger port; // Port on which the model server is running
     private ReentrantLock lock;
-    private int responseTimeout;
+    private int responseTimeoutSeconds;
     private WorkerThread serverThread;
     // Total number of subsequent inference request failures
     private AtomicInteger failedInfReqs;
@@ -198,12 +198,12 @@ public class Model {
         failedInfReqs.set(0);
     }
 
-    public int getResponseTimeout() {
-        return ConfigManager.getInstance().isDebug() ? Integer.MAX_VALUE : responseTimeout;
+    public int getResponseTimeoutSeconds() {
+        return ConfigManager.getInstance().isDebug() ? Integer.MAX_VALUE : responseTimeoutSeconds;
     }
 
-    public void setResponseTimeout(int responseTimeout) {
-        this.responseTimeout = responseTimeout;
+    public void setResponseTimeoutSeconds(int responseTimeoutSeconds) {
+        this.responseTimeoutSeconds = responseTimeoutSeconds;
     }
 
     public WorkerThread getServerThread() {

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/ModelManager.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/ModelManager.java
@@ -78,7 +78,7 @@ public final class ModelManager {
                 null,
                 1,
                 100,
-                configManager.getDefaultResponseTimeout(),
+                configManager.getDefaultResponseTimeoutSeconds(),
                 defaultModelName,
                 preloadModel);
     }
@@ -90,7 +90,7 @@ public final class ModelManager {
             String handler,
             int batchSize,
             int maxBatchDelay,
-            int responseTimeout,
+            int responseTimeoutSeconds,
             String defaultModelName,
             String preloadModel)
             throws ModelException, IOException, InterruptedException, ExecutionException,
@@ -121,7 +121,7 @@ public final class ModelManager {
         Model model = new Model(archive, configManager.getJobQueueSize(), preloadModel);
         model.setBatchSize(batchSize);
         model.setMaxBatchDelay(maxBatchDelay);
-        model.setResponseTimeout(responseTimeout);
+        model.setResponseTimeoutSeconds(responseTimeoutSeconds);
         Model existingModel = models.putIfAbsent(modelName, model);
         if (existingModel != null) {
             // model already exists

--- a/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
+++ b/frontend/server/src/main/java/com/amazonaws/ml/mms/wlm/WorkerThread.java
@@ -139,13 +139,13 @@ public class WorkerThread implements Runnable {
 
     private void runWorker()
             throws WorkerInitializationException, InterruptedException, FileNotFoundException {
-        int responseTimeout = model.getResponseTimeout();
+        int responseTimeoutSeconds = model.getResponseTimeoutSeconds();
         while (isRunning()) {
             req = aggregator.getRequest(backendChannel.id().asLongText(), state);
             backendChannel.writeAndFlush(req).sync();
             long begin = System.currentTimeMillis();
             // TODO: Change this to configurable param
-            ModelWorkerResponse reply = replies.poll(responseTimeout, TimeUnit.MINUTES);
+            ModelWorkerResponse reply = replies.poll(responseTimeoutSeconds, TimeUnit.SECONDS);
             long duration = System.currentTimeMillis() - begin;
             logger.info("Backend response time: {}", duration);
 

--- a/frontend/server/src/test/java/com/amazonaws/ml/mms/util/ConfigManagerTest.java
+++ b/frontend/server/src/test/java/com/amazonaws/ml/mms/util/ConfigManagerTest.java
@@ -90,7 +90,7 @@ public class ConfigManagerTest {
         ConfigManager configManager = ConfigManager.getInstance();
         configManager.setProperty("keystore", "src/test/resources/keystore.p12");
         Assert.assertEquals("true", configManager.getEnableEnvVarsConfig());
-        Assert.assertEquals(130, configManager.getDefaultResponseTimeout());
+        Assert.assertEquals(60 * 130, configManager.getDefaultResponseTimeoutSeconds());
 
         Dimension dimension;
         List<Metric> metrics = new ArrayList<>();
@@ -124,6 +124,20 @@ public class ConfigManagerTest {
         ConfigManager.init(args);
         ConfigManager configManager = ConfigManager.getInstance();
         Assert.assertEquals("false", configManager.getEnableEnvVarsConfig());
-        Assert.assertEquals(120, configManager.getDefaultResponseTimeout());
+        Assert.assertEquals(60 * 120, configManager.getDefaultResponseTimeoutSeconds());
+    }
+
+    @Test
+    public void testResponseTimeoutSeconds()
+            throws IOException, GeneralSecurityException, IllegalAccessException,
+                    NoSuchFieldException, ClassNotFoundException {
+        System.setProperty("mmsConfigFile", "src/test/resources/config.properties");
+        modifyEnv("MMS_DEFAULT_RESPONSE_TIMEOUT_SECONDS", "130");
+        ConfigManager.Arguments args = new ConfigManager.Arguments();
+        args.setModels(new String[] {"noop_v0.1"});
+        ConfigManager.init(args);
+        ConfigManager configManager = ConfigManager.getInstance();
+        Assert.assertEquals("true", configManager.getEnableEnvVarsConfig());
+        Assert.assertEquals(130, configManager.getDefaultResponseTimeoutSeconds());
     }
 }


### PR DESCRIPTION
Before or while filing an issue please feel free to join our [<img src='../docs/images/slack.png' width='20px' /> slack channel](https://join.slack.com/t/mms-awslabs/shared_invite/enQtNDk4MTgzNDc5NzE4LTBkYTAwMjBjMTVmZTdkODRmYTZkNjdjZGYxZDI0ODhiZDdlM2Y0ZGJiZTczMGY3Njc4MmM3OTQ0OWI2ZDMyNGQ) to get in touch with development team, ask questions, find out what's cooking and more!

## Issue #, if available:

## Description of changes:
Response timeout is documented to be in seconds. However, in the actual code, it's interpreted in minutes.

By the way, TorchServe has the exact same config variable, but it's interpreted in seconds.

For backward compatibility reasons, it feels risky to just change it, since it could theoretically break a bunch of models currently working in production. So, for now, this PR changes the internal logic to process the timeout in seconds, and uses "seconds" in the variable name for all related variables that represent the timeout in seconds. It then adds an extra config with a "_SECONDS" prefix, to give users a way to configure a timeout in seconds (with less than a minute).

We'll probably just change it to work as documented later. But at least this unblocks customers that want a timeout that's less then one minute, which the code before this PR doesn't allow for that at all.

## Testing done:

Added a new unit test and verified that the code builds and the unit tests pass.

**To run CI tests on your changes refer [README.md](https://github.com/awslabs/multi-model-server/blob/master/ci/README.md)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
